### PR TITLE
Add rust-analyzer to build inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
 
                 # Required for sensible bash in vscode :(
                 bashInteractive
+                rust-analyzer
               ];
 
               meta = with pkgs.lib; {


### PR DESCRIPTION
While the rust analyzer isn't really a build dependency, adding it like
this is the easiest way to make it available in the nix-develop shell.
