### PR TITLE
Pass commit message into stacked commits

### DIFF
--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -52,7 +52,7 @@ enum Commands {
     Init,
 
     /// Create a new or update an existing Pull Request on GitHub
-    Stacked,
+    Stacked(commands::stacked::StackedOptions),
 
     /// Create a new or update an existing Pull Request on GitHub from the
     /// current HEAD commit
@@ -199,7 +199,7 @@ pub async fn spr() -> Result<()> {
         Commands::List => commands::list::list(graphql_client, &config).await?,
         Commands::Patch(opts) => commands::patch::patch(opts, &jj, &mut gh, &config).await?,
         Commands::Close(opts) => commands::close::close(opts, &jj, &mut gh, &config).await?,
-        Commands::Stacked => commands::stacked::stacked(&jj, &mut gh, &config).await?,
+        Commands::Stacked(opts) => commands::stacked::stacked(&jj, &mut gh, &config, opts).await?,
         // The following commands are executed above and return from this
         // function before it reaches this match.
         Commands::Init | Commands::Format(_) => (),


### PR DESCRIPTION
This allows users to provide more information about what changes they
are doing.
