### PR TITLE
Respect the base commit of changes for patch

### DIFF
--- a/spr/src/jj.rs
+++ b/spr/src/jj.rs
@@ -126,6 +126,10 @@ impl RevSet {
         o.ancestors().without(&self.ancestors())
     }
 
+    pub fn fork_point(&self, o: &Self) -> Self {
+        RevSet(format!("fork_point(({}) | ({}))", self.0, o.0))
+    }
+
     // Unary
     pub fn ancestors(&self) -> Self {
         RevSet(format!("::({})", self.0))

--- a/spr/src/testing/git.rs
+++ b/spr/src/testing/git.rs
@@ -18,15 +18,6 @@ pub fn add_commit_and_push_to_remote<B: Display>(repo: &git2::Repository, branch
         flags_extended: 0,
         path: Vec::from("test.txt".as_bytes()),
     };
-    index
-        .add_frombuffer(&entry, "PR change".as_bytes())
-        .expect("Expected to be able to read from buffer");
-    let sig = git2::Signature::new("User", "user@example.com", &Time::new(0, 0))
-        .expect("Failed to build commit signature");
-    let tree_oid = index.write_tree().expect("Failed to write tree to disk");
-    let tree = repo
-        .find_tree(tree_oid)
-        .expect("Failed to find tree from OID");
     let trunk = repo
         .find_commit(
             repo.revparse_single("HEAD")
@@ -34,6 +25,15 @@ pub fn add_commit_and_push_to_remote<B: Display>(repo: &git2::Repository, branch
                 .id(),
         )
         .expect("Failed to find commit for HEAD");
+    index
+        .add_frombuffer(&entry, format!("change on {} on {}", trunk.id(), branch).as_ref())
+        .expect("Expected to be able to read from buffer");
+    let sig = git2::Signature::new("User", "user@example.com", &Time::new(0, 0))
+        .expect("Failed to build commit signature");
+    let tree_oid = index.write_tree().expect("Failed to write tree to disk");
+    let tree = repo
+        .find_tree(tree_oid)
+        .expect("Failed to find tree from OID");
     let commit_oid = repo
         .commit(None, &sig, &sig, "Test commit", &tree, &[&trunk])
         .expect("Failed to commit to repo");


### PR DESCRIPTION
New revisions created by patch will use the base commit of the actual change instead of basing them on the current HEAD of the main branch.
This guarantees that the changes make sense and don't accidentally revert further changes that have been done.

close #23
