### PR TITLE
Add basic GitHubAdapter trait

### DIFF
--- a/spr/src/github.rs
+++ b/spr/src/github.rs
@@ -570,9 +570,6 @@ pub trait GHPullRequest {
 }
 
 pub trait GitHubAdapter {
-    //    fn get_user(
-    //        &mut self,
-    //    ) -> impl std::future::Future<Output = crate::error::Result<String>> + Send;
     type PRAdapter: Send;
 
     fn pull_request(


### PR DESCRIPTION
This trait will allow moving subcommands to a more testable structure
that takes both a GH and JJ object that the test environment controls.

While the JJ object can easily be constructured fully locally, it's hard
to do so for the GH without this indirection.
