### PR TITLE
Use new global ID format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "git2",
  "git2-ext",
  "graphql_client",
+ "http",
  "indoc",
  "lazy-regex",
  "octocrab",

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -23,6 +23,7 @@ futures-lite = "^2.6.1"
 git2 = { version = "^0.20.2", default-features = false }
 git2-ext = "0.6.0"
 graphql_client = "^0.14.0"
+http = "1.4.0"
 indoc = "^2.0.6"
 lazy-regex = "^3.4.1"
 octocrab = { version = "^0.48.0", default-features = false, features = ["rustls", "rustls-ring", "default-client"] }

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -110,6 +110,10 @@ pub async fn spr() -> Result<()> {
 
     let crab = octocrab::OctocrabBuilder::default()
         .personal_token(github_auth_token.clone())
+        .add_header(
+            http::header::HeaderName::from_static("x-github-next-global-id"),
+            String::from("1"),
+        )
         .build()?;
 
     let mut headers = header::HeaderMap::new();


### PR DESCRIPTION
We don't store any IDs locally, so we can just move and make github happy.