### PR TITLE
Introduce mechanism to run fix on push

### DIFF
--- a/spr/src/commands/push.rs
+++ b/spr/src/commands/push.rs
@@ -23,6 +23,9 @@ pub struct PushOptions {
 
     #[clap(long, short = 'f')]
     force: bool,
+
+    #[clap(long)]
+    fix: Option<bool>,
 }
 
 #[cfg(test)]
@@ -478,9 +481,15 @@ where
     let revset = heads
         .ancestors()
         .without(&RevSet::immutable().or(&RevSet::description("exact:\"\"")));
+    if opts.fix.unwrap_or(config.push.autofix) {
+        setup.set_message("Running jj fix");
+        jj.fix(&revset)?;
+    }
+
+    setup.set_message("Reading revisions");
     let revisions = jj.read_revision_range(config, &revset)?;
 
-    setup.set_message(format!("Validating revisions are ready"));
+    setup.set_message("Checking revisions for bad states");
     let blockers = jj.revset_to_change_ids(
         &revset.and(
             &RevSet::conflicts()

--- a/spr/src/config/main.rs
+++ b/spr/src/config/main.rs
@@ -16,6 +16,8 @@ struct ParseConfig {
     drawing: super::drawing::Drawing,
     #[serde(default)]
     icons: super::icons::Icons,
+    #[serde(default)]
+    push: super::push::PushConfig,
 }
 
 // Both `jj config list` and `jj config get` return valid yaml.
@@ -38,6 +40,7 @@ pub struct Config {
 
     pub drawing: super::drawing::Drawing,
     pub icons: super::icons::Icons,
+    pub push: super::push::PushConfig,
 }
 
 impl Config {
@@ -49,6 +52,7 @@ impl Config {
         branch_prefix: String,
         drawing: super::drawing::Drawing,
         icons: super::icons::Icons,
+        push: super::push::PushConfig,
     ) -> Self {
         Self {
             owner,
@@ -58,6 +62,7 @@ impl Config {
             branch_prefix,
             drawing,
             icons,
+            push,
         }
     }
 
@@ -266,6 +271,7 @@ pub async fn from_jj<F: AsyncFnOnce() -> crate::error::Result<String>>(
         branch_prefix,
         parsed.drawing,
         parsed.icons,
+        parsed.push,
     ))
 }
 

--- a/spr/src/config/mod.rs
+++ b/spr/src/config/mod.rs
@@ -3,3 +3,4 @@ pub use main::*;
 
 pub mod drawing;
 pub mod icons;
+pub mod push;

--- a/spr/src/config/push.rs
+++ b/spr/src/config/push.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+fn default_autofix() -> bool {
+    false
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PushConfig {
+    #[serde(default = "default_autofix")]
+    pub autofix: bool,
+}
+
+impl Default for PushConfig {
+    fn default() -> Self {
+        Self { autofix: false }
+    }
+}

--- a/spr/src/jj.rs
+++ b/spr/src/jj.rs
@@ -787,6 +787,11 @@ impl Jujutsu {
 
         Ok(output.trim() == "true")
     }
+
+    pub fn fix(&mut self, source: &RevSet) -> Result<()> {
+        self.run_captured_with_args(["fix", "--source", source.as_ref()])
+            .map(|_| {})
+    }
 }
 
 fn get_jj_bin() -> PathBuf {

--- a/spr/src/testing/config.rs
+++ b/spr/src/testing/config.rs
@@ -9,5 +9,6 @@ pub fn basic() -> crate::config::Config {
         "spr/test/".into(),
         crate::config::drawing::Drawing::default(),
         crate::config::icons::Icons::default(),
+        crate::config::push::PushConfig::default(),
     )
 }


### PR DESCRIPTION
This can be configured to be run automatically.
Makes sure every commit pushed via spr is properly formatted via the
formatters configured for `jj fix`.
Disabled by default because `jj fix` fails when there's no formatters
and modifies files somewhat magically.