### PR TITLE
Add `first:` argment to pullRequests query

### DIFF
--- a/spr/src/gql/update_issuecomment.graphql
+++ b/spr/src/gql/update_issuecomment.graphql
@@ -58,7 +58,7 @@ query ByHead(
   $head: String!
 ) {
   repository(owner: $owner, name: $name) {
-    pullRequests(headRefName: $head, first: 1000) {
+    pullRequests(headRefName: $head, first: 10) {
       nodes {
         ...PR
       }

--- a/spr/src/gql/update_issuecomment.graphql
+++ b/spr/src/gql/update_issuecomment.graphql
@@ -58,7 +58,7 @@ query ByHead(
   $head: String!
 ) {
   repository(owner: $owner, name: $name) {
-    pullRequests(headRefName: $head) {
+    pullRequests(headRefName: $head, first: 1000) {
       nodes {
         ...PR
       }


### PR DESCRIPTION
This is required by github to actually return anything.
For exceedingly large repositories we might have to iterate properly either way, so this might not be the end of improving this query.