### PR TITLE
fix(fetch): skip pulling code changes for closed PRs

### DIFF
--- a/spr/src/commands/fetch.rs
+++ b/spr/src/commands/fetch.rs
@@ -119,6 +119,7 @@ where
 
         // Ok, we want to update our local change with any code changes that were done upstream
         if opts.pull_code_changes
+            && !work.pull_request.closed()
             && let Some(old_rev) = work.revision.message.get(&MessageSection::LastCommit)
         {
             let head_revset = {


### PR DESCRIPTION
Avoids error when remote branch is deleted after merge.