### PR TITLE
✨ push: add support for pushing draft pull requests

### DIFF
--- a/spr/src/commands/push.rs
+++ b/spr/src/commands/push.rs
@@ -26,6 +26,9 @@ pub struct PushOptions {
 
     #[clap(long)]
     fix: Option<bool>,
+
+    #[clap(long, num_args = 0..=1, default_missing_value = "true")]
+    pub draft: Option<bool>,
 }
 
 #[cfg(test)]
@@ -58,6 +61,11 @@ impl PushOptions {
 
     pub fn with_existing(mut self, val: bool) -> Self {
         self.existing = val;
+        self
+    }
+
+    pub fn with_draft(mut self, val: bool) -> Self {
+        self.draft = Some(val);
         self
     }
 }
@@ -504,6 +512,7 @@ where
     PR: crate::github::GHPullRequest,
     GH: crate::github::GitHubAdapter<PRAdapter = PR>,
 {
+    let draft = opts.draft.unwrap_or(config.push.draft);
     let multi = indicatif::MultiProgress::new();
     let setup = multi.add(
         indicatif::ProgressBar::new(100).with_style(
@@ -671,7 +680,7 @@ where
                 body,
                 &workset.pull_request.base_branch,
                 &workset.pull_request.head_branch,
-                false,
+                draft,
             )
             .await?;
 
@@ -2451,5 +2460,97 @@ pub mod tests {
                 == pr2_oid,
             "PR 1 should be based on PR 2"
         );
+    }
+
+    #[test]
+    fn test_push_options_parsing() {
+        use clap::Parser;
+
+        let opts = super::PushOptions::try_parse_from(&["spr"]).unwrap();
+        assert_eq!(opts.draft, None);
+
+        let opts = super::PushOptions::try_parse_from(&["spr", "--draft"]).unwrap();
+        assert_eq!(opts.draft, Some(true));
+
+        let opts = super::PushOptions::try_parse_from(&["spr", "--draft=true"]).unwrap();
+        assert_eq!(opts.draft, Some(true));
+
+        let opts = super::PushOptions::try_parse_from(&["spr", "--draft=false"]).unwrap();
+        assert_eq!(opts.draft, Some(false));
+    }
+
+    #[tokio::test]
+    async fn test_push_draft_cli_override() {
+        let (_temp_dir, mut jj, _bare) = testing::setup::repo_with_origin();
+        let _ = create_jujutsu_commit(&mut jj, "Test commit", "file 1");
+
+        let mut gh = crate::github::fakes::GitHub {
+            pull_requests: std::collections::BTreeMap::new(),
+        };
+
+        super::push(
+            &mut jj,
+            &mut gh,
+            &testing::config::basic(),
+            super::PushOptions::default().with_draft(true),
+        )
+        .await
+        .expect("Push failed");
+
+        assert_eq!(gh.pull_requests.len(), 1);
+        let pr = gh.pull_requests.get(&1).expect("PR 1 should exist");
+        assert!(pr.draft, "PR should be a draft");
+    }
+
+    #[tokio::test]
+    async fn test_push_draft_config_fallback() {
+        let (_temp_dir, mut jj, _bare) = testing::setup::repo_with_origin();
+        let _ = create_jujutsu_commit(&mut jj, "Test commit", "file 1");
+
+        let mut config = testing::config::basic();
+        config.push.draft = true;
+
+        let mut gh = crate::github::fakes::GitHub {
+            pull_requests: std::collections::BTreeMap::new(),
+        };
+
+        super::push(
+            &mut jj,
+            &mut gh,
+            &config,
+            super::PushOptions::default(),
+        )
+        .await
+        .expect("Push failed");
+
+        assert_eq!(gh.pull_requests.len(), 1);
+        let pr = gh.pull_requests.get(&1).expect("PR 1 should exist");
+        assert!(pr.draft, "PR should be a draft");
+    }
+
+    #[tokio::test]
+    async fn test_push_draft_cli_override_false() {
+        let (_temp_dir, mut jj, _bare) = testing::setup::repo_with_origin();
+        let _ = create_jujutsu_commit(&mut jj, "Test commit", "file 1");
+
+        let mut config = testing::config::basic();
+        config.push.draft = true;
+
+        let mut gh = crate::github::fakes::GitHub {
+            pull_requests: std::collections::BTreeMap::new(),
+        };
+
+        super::push(
+            &mut jj,
+            &mut gh,
+            &config,
+            super::PushOptions::default().with_draft(false),
+        )
+        .await
+        .expect("Push failed");
+
+        assert_eq!(gh.pull_requests.len(), 1);
+        let pr = gh.pull_requests.get(&1).expect("PR 1 should exist");
+        assert!(!pr.draft, "PR should NOT be a draft");
     }
 }

--- a/spr/src/config/main.rs
+++ b/spr/src/config/main.rs
@@ -648,5 +648,24 @@ mod tests {
             let parsed = parsed_from_jj(&jj).expect("Shouldn't fail to parse config");
             assert_eq!(parsed.drawing.space, " ");
         }
+
+        #[test]
+        fn test_parse_push_draft() {
+            let (_tmpdir, mut jj, _) = testing::setup::repo_with_origin();
+
+            jj.config_set("spr.push.draft", "true", false)
+                .expect("Failed to set spr.push.draft");
+
+            let parsed = parsed_from_jj(&jj).expect("Shouldn't fail to parse config");
+            assert!(parsed.push.draft);
+        }
+
+        #[test]
+        fn test_parse_push_draft_default() {
+            let (_tmpdir, jj, _) = testing::setup::repo_with_origin();
+
+            let parsed = parsed_from_jj(&jj).expect("Shouldn't fail to parse config");
+            assert!(!parsed.push.draft);
+        }
     }
 }

--- a/spr/src/config/push.rs
+++ b/spr/src/config/push.rs
@@ -4,14 +4,23 @@ fn default_autofix() -> bool {
     false
 }
 
+fn default_draft() -> bool {
+    false
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PushConfig {
     #[serde(default = "default_autofix")]
     pub autofix: bool,
+    #[serde(default = "default_draft")]
+    pub draft: bool,
 }
 
 impl Default for PushConfig {
     fn default() -> Self {
-        Self { autofix: false }
+        Self {
+            autofix: false,
+            draft: false,
+        }
     }
 }

--- a/spr/src/github/fakes.rs
+++ b/spr/src/github/fakes.rs
@@ -20,6 +20,7 @@ impl super::types::PullRequest {
             comments: Vec::new(),
             node: String::new(),
             closed: false,
+            draft: false,
         }
     }
 }
@@ -67,7 +68,7 @@ impl super::GitHubAdapter for &mut GitHub {
         body: Sb,
         base_ref_name: B,
         head_ref_name: H,
-        _draft: bool,
+        draft: bool,
     ) -> crate::error::Result<Self::PRAdapter>
     where
         H: AsRef<str>,
@@ -81,13 +82,14 @@ impl super::GitHubAdapter for &mut GitHub {
             .map(|(k, _)| *k)
             .max()
             .unwrap_or(0);
-        let pr = Self::PRAdapter::new(
+        let mut pr = Self::PRAdapter::new(
             base_ref_name.as_ref(),
             head_ref_name.as_ref(),
             max + 1,
             title,
             body,
         );
+        pr.draft = draft;
 
         self.pull_requests.insert(pr.number, pr.clone());
 

--- a/spr/src/github/real.rs
+++ b/spr/src/github/real.rs
@@ -70,6 +70,7 @@ impl From<old_comments::OldCommentsRepositoryPullRequest> for super::types::Pull
             body: pr.body,
             title: pr.title,
             closed: pr.closed,
+            draft: pr.is_draft,
             _reviewers: reviewers,
             _assignees: assignees,
             comments,
@@ -238,6 +239,7 @@ impl super::GitHubAdapter for &mut GitHub {
             _assignees: Vec::new(),
             comments: Vec::new(),
             closed: false,
+            draft,
         })
     }
 

--- a/spr/src/github/types.rs
+++ b/spr/src/github/types.rs
@@ -17,6 +17,7 @@ pub struct PullRequest {
     pub _assignees: Vec<String>,
     pub comments: Vec<PullRequestComment>,
     pub closed: bool,
+    pub draft: bool,
 }
 
 impl super::GithubPRComment for PullRequestComment {

--- a/spr/src/gql/update_issuecomment.graphql
+++ b/spr/src/gql/update_issuecomment.graphql
@@ -19,6 +19,7 @@ fragment PR on PullRequest {
   headRefName
   closed
   merged
+  isDraft
   comments(first: 100) {
     nodes {
       body


### PR DESCRIPTION
Introduce --draft CLI flag and spr.push.draft configuration to allow pushing pull requests in draft state.

#### Why

Support pushing draft pull requests using the --draft CLI flag or spr.push.draft configuration.

#### The code changes include:

- Add `draft` field to `PushConfig` and default it to `false`.
- Add `draft` field to `PullRequest` model and update GraphQL query to fetch `isDraft`.
- Update `real` and `fakes` GitHub adapters to support `draft` status.
- Add `draft` option to `PushOptions` CLI options.
- Update `push` command to resolve draft status and pass it to `new_pull_request`.
- Add unit and integration tests for CLI parsing and push draft behavior.

go/traj/47f0453c-c152-4121-90cc-ac82c8774421
TESTED=manually
RELNOTES=NONE
TAG=agy
CONV=4ef8c914-cbfd-45b5-a0fd-661a9cba8365
