### PR TITLE
📝 install: recommend --locked for cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Jujutsu encourages amending changes. GitHub's review UI breaks with force pushes
 ```bash
 git clone https://github.com/Ongy/jj-spr.git
 cd jj-spr
-cargo install --path spr
+cargo install --locked --path spr
 ```
 
 This installs the `jj-spr` binary to your `~/.cargo/bin` directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ Here's a complete example to get you started quickly:
 # 1. Install jj-spr (after installing Rust from https://rustup.rs)
 git clone https://github.com/Ongy/jj-spr.git
 cd jj-spr
-cargo install --path spr
+cargo install --locked --path spr
 
 # 2. Set up the Jujutsu alias
 jj config set --user aliases.spr '["util", "exec", "--", "jj-spr"]'

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -15,7 +15,7 @@ jj-spr is written in Rust. You need a Rust toolchain to build from source. See [
 ```shell
 git clone https://github.com/Ongy/jj-spr.git
 cd jj-spr
-cargo install --path spr
+cargo install --locked --path spr
 ```
 
 This will install the `jj-spr` binary to your `~/.cargo/bin` directory.


### PR DESCRIPTION
Update installation instructions to recommend using `--locked` flag to ensure reproducible builds from source.

#### Why

Without `--locked`, `cargo install` might update dependencies (like `octocrab`) to newer versions that are incompatible with the locked codebase, leading to runtime errors.

#### The code changes include:

- Updated `README.md` and docs to use `cargo install --locked --path spr`.

go/traj/47f0453c-c152-4121-90cc-ac82c8774421
TESTED=N/A
RELNOTES=NONE
TAG=agy
CONV=4ef8c914-cbfd-45b5-a0fd-661a9cba8365